### PR TITLE
Fix: add cors origin for Citadel

### DIFF
--- a/apps/api/src/middleware/cors.js
+++ b/apps/api/src/middleware/cors.js
@@ -8,6 +8,7 @@ module.exports = cors({
       !origin ||
       origin.match(/^http:\/\/localhost:\d+$/) ||
       origin.match(/^http:\/\/umbrel(.*?).local(:\d+)?$/) ||
+      origin.match(/^http:\/\/citadel(.*?).local(:\d+)?$/) ||
       origin.match(`http://${process.env.APP_HIDDEN_SERVICE}`) ||
       origin.match(`http://${process.env.APP_DOMAIN}`)
     ) {


### PR DESCRIPTION
Citadel users are reporting the app doesn't work for them. This should fix the issue.

maybe related to #30